### PR TITLE
mention that release builds since ver48 can no longer do this by way of about:config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Except as noted below, this catalog is released under [Mozilla Public License, v
 
 ### Compatibility and installation
 
-This add-on has been tested with the following browsers (in alphabetical order): Basilisk RC1, Firefox ESR 45-52, Firefox 45-58b, Pale Moon 27 and Waterfox 55. In order to install it into Firefox release or beta, you need to disable the extensions signing requirement. Multi-process mode (e10s) is not supported. The installation package is located in the [releases](https://github.com/JustOff/ca-archive/releases) section.
+This add-on has been tested with the following browsers (in alphabetical order): Basilisk RC1, Firefox ESR 45-52, Firefox 45-58b, Pale Moon 27 and Waterfox 55. In order to install it into Firefox release or beta, you need to disable the extensions signing requirement. In firefox release builds since version 48 the official method to disable the signing requirement in about:config was removed. Multi-process mode (e10s) is not supported. The installation package is located in the [releases](https://github.com/JustOff/ca-archive/releases) section.


### PR DESCRIPTION
I thought it deserved a mention to save people having to look up how to disable it and then find there was no point because `xpinstall.signatures.required` doesn't work anymore for more recent firefox releases.