### PR TITLE
De-localise addons.mozilla.org/firefox/

### DIFF
--- a/content/ca-archive.html
+++ b/content/ca-archive.html
@@ -65,7 +65,7 @@
               <li id="more">
                 <a href="caa:">More…</a>
                 <ul>
-                  <li><a target="_blank" href="https://addons.mozilla.org/en-US/firefox/">Live Firefox Add-ons Site</a></li>
+                  <li><a target="_blank" href="https://addons.mozilla.org/firefox/">Live Firefox Add-ons site</a></li>
                   <li><a target="_blank" href="http://web.archive.org/web/*/https://addons.mozilla.org/en-US/firefox/">Wayback Machine</a></li>
                   <li><a href="caa:about">About</a></li>
                 </ul>


### PR DESCRIPTION
More ▶ Live Firefox Add-ons site

- localized https://addons.mozilla.org/en-US/firefox/ has the _Change language_ menu at the foot of the US page
- non-localised https://addons.mozilla.org/firefox/ will redirect automatically.